### PR TITLE
Add verification module with checks for valid discretisation

### DIFF
--- a/src/scicomp/utils/verification.py
+++ b/src/scicomp/utils/verification.py
@@ -10,7 +10,7 @@ def check_valid_spatial_discretisation(
 
     Assuming that dy=dx, discretisation of a rectangle using N grid points
     should yield an integer number of grid points in the y-direction, with
-    the boundaries (y_min, y_max) explicitly represented.
+    the boundaries explicitly represented.
 
     We verify this by calculating dx = width / N, and checking that
     dx does indeed divide height exactly. Fractions are used to prevent

--- a/src/scicomp/utils/verification.py
+++ b/src/scicomp/utils/verification.py
@@ -1,0 +1,32 @@
+"""Functions for finite difference verification."""
+
+from fractions import Fraction
+
+
+def check_valid_spatial_discretisation(
+    width: Fraction | int, height: Fraction | int, n: int
+) -> bool:
+    """Verify that N gives a valid discretisation of a given rectangle.
+
+    Assuming that dy=dx, discretisation of a rectangle using N grid points
+    should yield an integer number of grid points in the y-direction, with
+    the boundaries (y_min, y_max) explicitly represented.
+
+    We verify this by calculating dx = width / N, and checking that
+    dx does indeed divide height exactly. Fractions are used to prevent
+    floating-point arithmetic errors.
+
+    Args:
+        width: Physical width of the rectangle.
+        height: Physical height of the rectangle.
+        n: Number of grid points with which to discretise the x-axis.
+
+    Returns:
+        Boolean value indicating that N yields (or does not yield) a valid
+        scheme.
+    """
+    width = Fraction(width)
+    height = Fraction(height)
+    dx = Fraction(numerator=width, denominator=n)
+    dy = height * (1 / dx)
+    return dy.denominator == 1

--- a/tests/test_discretisation_validity.py
+++ b/tests/test_discretisation_validity.py
@@ -1,0 +1,57 @@
+from fractions import Fraction
+
+from hypothesis import given
+from hypothesis.strategies import fractions, integers, one_of
+
+from scicomp.utils.verification import check_valid_spatial_discretisation
+
+
+@given(
+    width=one_of(
+        integers(min_value=1),
+        fractions(min_value=1e-6),
+    ),
+    n=integers(min_value=1),
+)
+def test_square_discretisation_always_valid_for_pos_n(width, n):
+    assert check_valid_spatial_discretisation(width=width, height=width, n=n)
+
+
+@given(
+    width=one_of(
+        integers(min_value=1),
+        fractions(min_value=1e-6),
+    ),
+    height_mult=integers(min_value=1),
+    n=integers(min_value=1),
+)
+def test_rect_discretisation_always_valid_for_height_multiple_of_width(
+    width, height_mult, n
+):
+    assert check_valid_spatial_discretisation(
+        width=width, height=height_mult * width, n=n
+    )
+
+
+def test_valid_discretisation_good_gcd():
+    """Scheme should be valid because dx=w/n divides both w and h."""
+    width = Fraction(3, 2)  # 1.5
+    height = Fraction(5, 2)  # 2.5
+    n = 3  # dx = 0.5, divides 1.5 and 2.5
+    assert check_valid_spatial_discretisation(width, height, n)
+
+
+def test_invalid_discretisation_bad_gcd():
+    """Scheme should be invalid because dx=w/n=1/2 does not divide 1.6"""
+    width = 1
+    height = Fraction(16, 10)
+    n = 2
+    assert not check_valid_spatial_discretisation(width, height, n)
+
+
+def test_invalid_discretisation_dx_larger_than_height():
+    """Scheme should be invalid because dx=w/n is larger than height."""
+    width = 6
+    height = Fraction(3, 2)
+    n = 2
+    assert not check_valid_spatial_discretisation(width, height, n)


### PR DESCRIPTION
Adds a `scicomp.verification` module, containing a function which checks whether a given combination of 'width', 'height', and 'N' yields a valid discretisation of a rectangle. 

If dy == dx, then the spatial discretisation implied by width / N should divide height as well.