### PR TITLE
Add basic plots

### DIFF
--- a/scripts/test_plot.py
+++ b/scripts/test_plot.py
@@ -1,0 +1,57 @@
+"""Plotting examples."""
+
+from fractions import Fraction
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from scicomp.visualisation import plot_circular_state, plot_rectangular_state
+
+
+def plot_grid_values():
+    """Example usage of functions to plot rect and circular domains."""
+    fig, axes = plt.subplots(1, 2, constrained_layout=True)
+
+    # ===============================
+    # Plot rectangle
+    # ===============================
+    frac_width = Fraction(6)
+    frac_height = Fraction(9)
+    nx: int = 1000
+    dx = frac_width / nx
+    ny = frac_height / dx
+
+    assert ny.is_integer()
+
+    width = float(frac_width)
+    height = float(frac_height)
+    ny = ny.numerator
+
+    X, Y = np.meshgrid(np.linspace(0, width, nx + 1), np.linspace(0, height, ny + 1))
+    state = np.sin(X) + np.cos(Y)
+    state[[0, -1]] = 0
+    state[:, [0, -1]] = 0
+    plot_rectangular_state(state, width, height, axes[0])
+
+    # ===============================
+    # Plot circle
+    # ===============================
+    frac_diameter = Fraction(6)
+    nx: int = 1000
+    dx = frac_diameter / nx
+
+    diameter = float(frac_diameter)
+    radius = diameter / 2
+    X, Y = np.meshgrid(
+        np.linspace(-radius, radius, nx + 1), np.linspace(-radius, radius, nx + 1)
+    )
+    mask = radius**2 > X**2 + Y**2
+    state = np.sin(X) + np.cos(Y)
+    state[~mask] = 0
+    plot_circular_state(state, diameter, nx, ax=axes[1])
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    plot_grid_values()

--- a/scripts/test_plot.py
+++ b/scripts/test_plot.py
@@ -5,7 +5,12 @@ from fractions import Fraction
 import matplotlib.pyplot as plt
 import numpy as np
 
-from scicomp.visualisation import plot_circular_state, plot_rectangular_state
+from scicomp.shape import Shape
+from scicomp.visualisation import (
+    plot_circular_state,
+    plot_eigenmode,
+    plot_rectangular_state,
+)
 
 
 def plot_grid_values():
@@ -53,5 +58,42 @@ def plot_grid_values():
     plt.show()
 
 
+def plot_eigenmodes():
+    """Plot some fake eigenmodes labelled by their eigenfrequencies."""
+    fig, axes = plt.subplots(1, 4, sharey=True, constrained_layout=True)
+
+    # Make grid roughly 4pi in each dimension
+    frac_width = Fraction(88 / 7)
+    frac_height = Fraction(88 / 7)
+    nx: int = 1000
+    dx = frac_width / nx
+    ny = frac_height / dx
+
+    assert ny.is_integer()
+
+    width = float(frac_width)
+    height = float(frac_height)
+    ny = ny.numerator
+
+    # Mock up some fake eigenthing results
+    X, Y = np.meshgrid(np.linspace(0, width, nx + 1), np.linspace(0, height, ny + 1))
+    eigenfrequencies = np.array([1 / 4, 1 / 2, 1.0, 2.0])
+    eigenmodes = np.sin(eigenfrequencies[:, None, None] * X[None, ...]) + np.cos(
+        eigenfrequencies[:, None, None] * Y[None, ...]
+    )
+    eigenmodes[:, [0, -1]] = 0
+    eigenmodes[:, :, [0, -1]] = 0
+
+    # Reshape into state vector, as this is the expected input
+    eigenmodes = np.reshape(eigenmodes, (4, -1))
+    for i, ef in enumerate(eigenfrequencies):
+        plot_eigenmode(
+            eigenmodes[i], ef, Shape.Square, axes[i], width=width, height=height
+        )
+
+    plt.show()
+
+
 if __name__ == "__main__":
     plot_grid_values()
+    plot_eigenmodes()

--- a/src/scicomp/shape.py
+++ b/src/scicomp/shape.py
@@ -1,0 +1,46 @@
+"""Define the shapes which are implemented for simulation."""
+
+import math
+from enum import StrEnum
+from fractions import Fraction
+
+import numpy as np
+import numpy.typing as npt
+
+
+class Shape(StrEnum):
+    """Shapes implemented for simulation."""
+
+    Circle = "circle"
+    Square = "square"
+    Rectangle = "rectangle"
+
+    def state_vec_to_grid(
+        self, state_vector: npt.NDArray[np.float64], n: int | None = None
+    ) -> npt.NDArray[np.float64]:
+        """Convert a state vector into the grid representation of associated shape."""
+        if state_vector.ndim != 1:
+            raise ValueError(
+                f"Expected state_vector with 1 dimension, but received argument "
+                f"has {state_vector.ndim}. Huh?"
+            )
+        match self:
+            case Shape.Square | Shape.Circle:
+                n = int(math.sqrt(state_vector.size))
+                if (n**2) != state_vector.size:
+                    raise TypeError(
+                        f"Invalid shape for {self} state_vector. Size is not a "
+                        "perfect square."
+                    )
+                grid = np.reshape(state_vector, (n, n))
+            case Shape.Rectangle:
+                if n is None:
+                    raise ValueError("Must supply n to reshape type Shape.Rectangle.")
+                ny = Fraction(state_vector.size, n)
+                if not ny.is_integer():
+                    raise TypeError(
+                        f"Invalid shape for rectangle state_vector with {n=}, "
+                        "n does not divide state_vector.size"
+                    )
+                grid = np.reshape(state_vector, (ny.numerator, n))
+        return grid

--- a/src/scicomp/visualisation.py
+++ b/src/scicomp/visualisation.py
@@ -6,6 +6,8 @@ import numpy.typing as npt
 from matplotlib.axes import Axes
 from matplotlib.image import AxesImage
 
+from scicomp.shape import Shape
+
 
 def plot_rectangular_state(
     z: npt.NDArray[np.float64], width: float, height: float, ax: Axes | None = None
@@ -69,3 +71,35 @@ def plot_circular_state(
         z, extent=(xc - radius, diameter, yc - radius, diameter), origin="lower"
     )
     return ax_im
+
+
+def plot_eigenmode(
+    eigenmode: npt.NDArray,
+    eigenfrequency: float,
+    shape: Shape,
+    ax: Axes | None = None,
+    **kwargs,
+) -> AxesImage:
+    """Plot an eigenmode of a given shape.
+
+    Args:
+        eigenmode: Numpy vector representing the eigenmode values in a state vector.
+        eigenfrequency: Eigenvalue associated with the eigenmode.
+        shape: Shape of the associated object.
+        ax: Matplotlib axis. If not provided, defaults to the current global axis.
+        **kwargs: Additional arguments to be passed to `plot_circular_state`
+            or `plot_rectangular_state`.
+
+    Returns:
+        Matplotlib AxesImage with heatmap of eigenmode.
+    """
+    if ax is None:
+        ax = plt.gca()
+    grid_values = shape.state_vec_to_grid(eigenmode)
+    match shape:
+        case Shape.Circle:
+            im_ax = plot_circular_state(grid_values, ax=ax, **kwargs)
+        case _:
+            im_ax = plot_rectangular_state(grid_values, ax=ax, **kwargs)
+    ax.set_title(f"$\\lambda = {eigenfrequency}$")
+    return im_ax

--- a/src/scicomp/visualisation.py
+++ b/src/scicomp/visualisation.py
@@ -1,0 +1,71 @@
+"""Plotting functions to analyse simulations."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+from matplotlib.axes import Axes
+from matplotlib.image import AxesImage
+
+
+def plot_rectangular_state(
+    z: npt.NDArray[np.float64], width: float, height: float, ax: Axes | None = None
+) -> AxesImage:
+    """Plot the values of a rectangular grid as a heatmap.
+
+    Values may be amplitude, concentration, or any other 1D quantity associated
+    with a grid.
+
+    Args:
+        z: Value at each grid node.
+        width: Width of the physical grid in SI units.
+        height: Height of the physical grid in SI units.
+        ax: Matplotlib axis. If not provided, defaults to the current global axis.
+
+    Returns:
+        Matplotlib AxesImage with heatmap of grid values.
+    """
+    if ax is None:
+        ax = plt.gca()
+    ax_im = ax.imshow(z, extent=(0, width, 0, height), origin="lower")
+    return ax_im
+
+
+def plot_circular_state(
+    z: npt.NDArray[np.float64],
+    diameter: float,
+    n: int,
+    center: tuple[float, float] = (0.0, 0.0),
+    ax: Axes | None = None,
+) -> AxesImage:
+    """Plot the values of a circular grid as a heatmap.
+
+    Values may be amplitude, concentration, or any other 1D quantity associated
+    with a grid.
+
+    Args:
+        z: Value at each grid node.
+        diameter: Diameter of the physical grid in SI units.
+        n: Number of grid points used to discretise the diameter.
+        center: Tuple containing (xc, yc), the coordinates of the circle center.
+        ax: Matplotlib axis. If not provided, defaults to the current global axis.
+
+    Returns:
+        Matplotlib AxesImage with heatmap of grid values.
+    """
+    if ax is None:
+        ax = plt.gca()
+
+    # Set points outside circle to None
+    radius = diameter / 2
+    X, Y = np.meshgrid(
+        np.linspace(-radius, radius, n + 1), np.linspace(-radius, radius, n + 1)
+    )
+    mask = radius**2 > X**2 + Y**2
+    z = z.copy()
+    z[~mask] = None
+
+    xc, yc = center
+    ax_im = ax.imshow(
+        z, extent=(xc - radius, diameter, yc - radius, diameter), origin="lower"
+    )
+    return ax_im


### PR DESCRIPTION
Adds a few plots:
- Plot the state of a grid for a rectangular, square, or circular shape
- Plot an eigenmode, with its associated eigenfrequency as a title.

You can test these out using an example script I've created with some mock data:

```bash
uv run scripts/test_plot.py
```

![CleanShot 2025-03-12 at 17 02 13@2x](https://github.com/user-attachments/assets/68a2f125-c0cb-419b-9a5a-8011b13a6a0e)

![CleanShot 2025-03-12 at 17 02 30@2x](https://github.com/user-attachments/assets/bace8e75-2d8f-4f5a-aaa8-4365d3335813)
