### PR TITLE
Add runge-kutta to 3.3

### DIFF
--- a/src/scicomp/cli/plots/spring_energy.py
+++ b/src/scicomp/cli/plots/spring_energy.py
@@ -11,7 +11,8 @@ from scicomp.oscillator.energy import (
     calculate_kinetic_energy,
     calculate_spring_energy,
 )
-from scicomp.oscillator.leapfrog import simulate_oscillator
+from scicomp.oscillator.leapfrog import simulate_oscillator as simulate_leapfrog
+from scicomp.oscillator.runge_kutta import simulate_oscillator as simulate_runge_kutta
 
 app = typer.Typer()
 
@@ -22,6 +23,8 @@ def spring_energy():
     m = 1
     k = 5
     x0 = 10
+    k = 1.2
+    x0 = 1
     v0 = 0
     dt = Fraction(1, 100)
     cycles = 2
@@ -32,45 +35,50 @@ def spring_energy():
     ).limit_denominator(100)
     runtime = float(runtime_frac)
 
-    states = simulate_oscillator(x0, v0, k, m, dt, runtime_frac)
-    e_kinetic = calculate_kinetic_energy(states[:, 0], m)
-    e_elastic = calculate_elastic_potential_energy(states[:, 1], k)
-    e_total = calculate_spring_energy(states[:, 1], states[:, 0], k, m)
-    initial_energy = calculate_spring_energy(states[0, 1], states[0, 0], k, m)
-
-    fig, ax = plt.subplots(figsize=(2.8, 1.5), constrained_layout=True)
-    ax.set_xlabel("Time ($s$)")
-    ax.set_ylabel("Energy ($J$)")
-    ax.spines["top"].set_visible(False)
-    ax.spines["right"].set_visible(False)
-
-    time_points = np.linspace(0, runtime, states.shape[0])
-    ax.plot(time_points, e_kinetic, linewidth=1, label="$E_k$")
-    ax.plot(time_points, e_elastic, linewidth=1, label="$E_p$")
-    ax.plot(time_points, e_total, linewidth=1, label="$E$")
-    ax.axhline(
-        y=initial_energy,
-        linewidth=0.5,
-        linestyle="dashed",
-        color="black",
-        label="$E_0$",
+    fig, axes = plt.subplots(
+        2, 1, figsize=(2.8, 2.0), sharex=True, constrained_layout=True
     )
+    solvers = (simulate_leapfrog, simulate_runge_kutta)
+    for ax, solver in zip(axes.flatten(), solvers, strict=True):
+        states = solver(x0, v0, k, m, dt, runtime_frac)
+        e_kinetic = calculate_kinetic_energy(states[:, 0], m)
+        e_elastic = calculate_elastic_potential_energy(states[:, 1], k)
+        e_total = calculate_spring_energy(states[:, 1], states[:, 0], k, m)
+        initial_energy = calculate_spring_energy(states[0, 1], states[0, 0], k, m)
 
-    ax.set_xlim(0, runtime)
-    ax.set_ylim(0, None)
-    ax.ticklabel_format(axis="y", style="scientific", scilimits=(0, 0))
-    ax.yaxis.get_offset_text().set_fontsize(6)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.yaxis.set_label_position("right")
 
-    ax.legend(
+        time_points = np.linspace(0, runtime, states.shape[0])
+        ax.plot(time_points, e_kinetic, linewidth=1, label="$E_k$")
+        ax.plot(time_points, e_elastic, linewidth=1, label="$E_p$")
+        ax.plot(time_points, e_total, linewidth=1, label="$E$")
+        ax.axhline(
+            y=initial_energy,
+            linewidth=0.5,
+            linestyle="dashed",
+            color="black",
+            label="$E_0$",
+        )
+
+        ax.set_xlim(0, runtime)
+        ax.set_ylim(0, None)
+
+    axes[0].legend(
         ncol=4,
         loc="lower center",
-        bbox_to_anchor=(0.55, 1.0),
+        bbox_to_anchor=(0.5, 1.0),
         fontsize=8,
         handlelength=0.8,
         columnspacing=0.5,
         labelspacing=0.2,
         frameon=False,
     )
+    axes[0].set_ylabel("LF", rotation=0, ha="left", va="center")
+    axes[1].set_ylabel("RK45", rotation=0, ha="left", va="center")
+    axes[1].set_xlabel("Time ($s$)")
+    fig.supylabel("Energy ($J$)")
 
     fig.savefig("results/figures/spring_1d_energy.png", bbox_inches="tight")
     fig.savefig("results/figures/spring_1d_energy.pdf", bbox_inches="tight")

--- a/src/scicomp/oscillator/runge_kutta.py
+++ b/src/scicomp/oscillator/runge_kutta.py
@@ -1,0 +1,71 @@
+"""Simulation of 1D harmonic oscillator using Runge-Kutta 4/5."""
+
+from fractions import Fraction
+
+import numpy as np
+import numpy.typing as npt
+from scipy.integrate import solve_ivp
+
+
+def oscillator_derivatives(_t, y, k: float, m: float) -> tuple[float, float]:
+    """1D harmonic oscillator position and velocity deriviatives.
+
+    For use in scipy.integrate.solve_ivp
+
+    Args:
+        _t: (Unused) current simulation time.
+        y: Tuple (x, v) position and velocity at time = `t`
+        k: Spring constant (N/m)
+        m: Mass at end of spring (kg)
+
+    Returns:
+        Tuple containing the time derivatives of position and velocity
+        at time = `t`.
+    """
+    x_i, v_i = y
+    dx_dt = v_i
+    dv_dt = -k * x_i / m
+    return (dx_dt, dv_dt)
+
+
+def simulate_oscillator(
+    x0: float,
+    v0: float,
+    k: float,
+    m: float,
+    dt: Fraction,
+    runtime: int | Fraction,
+) -> npt.NDArray[np.float64]:
+    """Simulate a spring under simple harmonic motion with Runge-Kutta 4/5.
+
+    Args:
+        x0: Initial position.
+        v0: Initial velocity.
+        k: Spring constant (N/m).
+        m: Mass of object at the end of the spring (kg).
+        dt: Duration of a discrete time-step.
+        runtime: Total duration to simulate.
+
+    Returns:
+        Numpy array with shape (time, 2), where the first column contains
+        velocity measurements, and the second contains position measurements.
+    """
+    n_steps_frac = runtime / dt
+    if not n_steps_frac.is_integer():
+        raise ValueError("`dt` does not divide `runtime`.")
+    else:
+        n_steps = int(n_steps_frac)
+        t_eval = np.linspace(0, float(runtime), n_steps + 1)
+
+    t_span = (0, runtime)
+    y0 = (x0, v0)
+    solution = solve_ivp(
+        oscillator_derivatives,
+        t_span=t_span,
+        y0=y0,
+        method="RK45",
+        t_eval=t_eval,
+        args=(k, m),
+    )
+
+    return solution.y.T


### PR DESCRIPTION
Adds comparison of energy over time between leapfrog and Runge-Kutta 4/5 for the 1D harmonic oscillator.

Test using `make -j`:
![spring_1d_energy](https://github.com/user-attachments/assets/af0bd24a-1078-42c4-a5e8-fe5564250d1a)
